### PR TITLE
Update README with corrected package names for Debian 12.6

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,3 @@
 Install the following packages (Debian 12) before running the build scripts:
 
-autoconf automake bash bc bison build-essential cmake flex gawk git gperf help2man libtool libtool-bin libusb-1.0 ncurses-dev python3 python3-venv rsync texinfo unzip wget
+autoconf automake bash bc bison build-essential cmake flex gawk git gperf help2man libtool libtool-bin libusb-1.0-0 libncurses-dev python3 python3-venv rsync texinfo unzip wget


### PR DESCRIPTION
Simple package name update.
By using the package names as is in the README, `libusb-1.0` is referred by a different name and `ncurses-dev` is `libncurses-dev`

Output:
```
easto@debian2:~$ sudo apt install autoconf automake bash bc bison build-essential cmake flex gawk git gperf help2man libtool libtool-bin libusb-1.0 ncurses-dev python3 python3-venv rsync texinfo unzip wget
[sudo] password for easto: 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'libncurses-dev' instead of 'ncurses-dev'
E: Unable to locate package libusb-1.0
E: Couldn't find any package by glob 'libusb-1.0'
```
```
easto@debian2:~$ apt-cache search libusb-1.0
libusb-1.0-0 - userspace USB programming library
libusb-1.0-0-dev - userspace USB programming library development files
libusb-1.0-doc - documentation for userspace USB programming
libusb-libusb-perl - Perl interface to the libusb-1.0 API
lm4flash - Command-line firmware flashing tool to communicate with the Stellaris Launchpad
libusb-ocaml - OCaml bindings to libusb-1.0 (runtime)
libusb-ocaml-dev - OCaml bindings to libusb-1.0
```